### PR TITLE
Removed  } which didnt make any sense

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Article.list(%{author: "Author"}) #=> %Xarango.QueryResult{result: [%Article{...
 Article.list(%{}, [sort: :author, per_page: 10] #=> serial pagination with cursor (fast)
 Article.list(%{}, [sort: :author, dir: :desc, per_page: 10, page: 1] #=> pagination with page nrs (skip, limit)
 
-Article.search(:text, "ips"}) #=> [%Article{..}]
+Article.search(:text, "ips") #=> [%Article{..}]
 
 Article.update(ipsum, %{status: "review"})
 Article.replace(lorem, %{author: "Author", text: "Foo"})


### PR DESCRIPTION
`Article.search(:text, "ips"})` isn't elixir legal expression, `}` doesn't have opening `{`. Based on code I edited documentation so it makes sense now..